### PR TITLE
Update Context.php

### DIFF
--- a/Context.php
+++ b/Context.php
@@ -163,6 +163,8 @@ class Context
 			$this->country = new Country((int)$cookie->id_country);
 			$this->customer = new CustomerBackwardModule((int)$cookie->id_customer);
 			$this->employee = new Employee((int)$cookie->id_employee);
+			
+			$this->customer->logged = $cookie->logged;
 		}
 		else
 		{


### PR DESCRIPTION
the isLogged function within Context.php doesn't actually work on PS v1.4.  The reason is because the customer logged public variable is always false.  
Instead, the context needs to copy the logged variable from cookie to customer
